### PR TITLE
BUG: Fixed unpickling error due to sklearn-update

### DIFF
--- a/examples/1-Infrastructure-Evaluation/1.2-Comparing-Infrastructure-Designs/1.2-comparing-infrastructure-designs.ipynb
+++ b/examples/1-Infrastructure-Evaluation/1.2-Comparing-Infrastructure-Designs/1.2-comparing-infrastructure-designs.ipynb
@@ -334,8 +334,17 @@
    },
    "outputs": [],
    "source": [
+    "# The custom unpicklers is due to SO user Pankaj Saini's answer:  https://stackoverflow.com/a/51397373/3896008\n",
+    "class CustomUnpicklerJPLdata(pickle.Unpickler):\n",
+    "    def find_class(self, module, name):\n",
+    "        if name == \"sklearn.mixture.gaussian_mixture\":\n",
+    "            return sklearn.mixture.GaussianMixture\n",
+    "        if name == \"GaussianMixture\":\n",
+    "            return sklearn.mixture.GaussianMixture\n",
+    "\n",
     "def get_synth_events(sessions_per_day):\n",
-    "    gmm = pickle.load(open('./data/jpl_weekday_40.pkl', 'rb'))\n",
+    "    gmm = CustomUnpicklerJPLdata(open('./data/jpl_weekday_40.pkl', \"rb\")).load()\n",
+    "\n",
     "\n",
     "    # Generate a list of the number of sessions to draw for each day.\n",
     "    # This generates 30 days of charging demands.\n",
@@ -347,7 +356,7 @@
     "    gen = GaussianMixtureEvents(pretrained_model=gmm, duration_min=0.08334)\n",
     "\n",
     "    synth_events = gen.generate_events(num_evs, PERIOD, VOLTAGE, DEFAULT_BATTERY_POWER)\n",
-    "    return synth_events"
+    "    return synth_events\n"
    ]
   },
   {

--- a/examples/1-Infrastructure-Evaluation/1.2-Comparing-Infrastructure-Designs/1.2-comparing-infrastructure-designs.ipynb
+++ b/examples/1-Infrastructure-Evaluation/1.2-Comparing-Infrastructure-Designs/1.2-comparing-infrastructure-designs.ipynb
@@ -341,6 +341,7 @@
     "            return sklearn.mixture.GaussianMixture\n",
     "        if name == \"GaussianMixture\":\n",
     "            return sklearn.mixture.GaussianMixture\n",
+    "        return super().find_class(module, name)\n",
     "\n",
     "def get_synth_events(sessions_per_day):\n",
     "    gmm = CustomUnpicklerJPLdata(open('./data/jpl_weekday_40.pkl', \"rb\")).load()\n",


### PR DESCRIPTION
The GMM module location has changed in the sklearn, hence the unpicking line throws an error. I fixed this using an SO user's answer @[Pankaj Saini](https://stackoverflow.com/users/7429675/pankaj-saini)'s answer  [https://stackoverflow.com/a/51397373/3896008](https://stackoverflow.com/a/51397373/3896008)  
Please feel free to merge/request additional changes.
@zach401 /@sunash 